### PR TITLE
自動更新機能の実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,6 +1,6 @@
 $(function() { 
   function buildHTML(message){
-    console.log(message.id)
+    
     var image = "";
 
     image = (message.image) ? `<img class="lower-message__image" src="${ massage.image }">`: "";

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,6 +1,6 @@
-$(function(){ 
+$(function() { 
   function buildHTML(message){
-
+    console.log(message.id)
     var image = "";
 
     image = (message.image) ? `<img class="lower-message__image" src="${ massage.image }">`: "";
@@ -44,4 +44,28 @@ $('.js-form').on('submit', function(e){
    });
    return false;
  });
+
+ var reloadMessages = function() {
+  last_message_id = $('.message:last').data("message-id");
+  group_id = $(group.id)
+  $.ajax({
+    url: `groups/${group_id}/api/messages`,
+    type: 'GET',
+    dataType: 'json',
+    data: {id: last_message_id},
+  })
+  .done(function(messages) {
+    var insertHTML = '';
+    messages.forEach(function (message) {
+    insertHTML = buildHTML(message);
+    $('.messages').append(insertHTML); 
+    $('div').animate({scrollTop: $('.messages').height()})
+    })
+  })
+  .fail(function () {
+    alert('自動更新に失敗しました');
+  });
+  setInterval(reloadMessages, 5000);
+  }  
 });
+   

--- a/app/controllers/api/messages_controller_controller.rb
+++ b/app/controllers/api/messages_controller_controller.rb
@@ -1,0 +1,7 @@
+class Api::MessagesController < ApplicationController
+  def index
+    group = Group.find(params[:group_id])
+    last_message_id = params[:id].to_i
+    @messages = group.messages.includes(:user).where("id > #{last_message_id}")
+  end
+end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -32,7 +32,7 @@ class GroupsController < ApplicationController
 
   private
   def group_params
-    params.require(:group).permit(:name, { :user_ids => [] })
+    params.require(:group).permit(:name, user_ids: [])
   end
 
   def set_group

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -32,7 +32,7 @@ class GroupsController < ApplicationController
 
   private
   def group_params
-    params.require(:group).permit(:name, user_ids: [] )
+    params.require(:group).permit(:name, { :user_ids => [] })
   end
 
   def set_group

--- a/app/views/api/messages_controller/index.json.jbuilder
+++ b/app/views/api/messages_controller/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image.url
+  json.created_at message.created_atstrftime("%Y/%m/%d %H:%M")
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -13,10 +13,10 @@
 
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
-      %label.chat-group-form__label{:for => "chat_group_チャットメンバーを追加"} チャットメンバーを追加
+      %label.chat-group-form__label{for: "chat_group_チャットメンバーを追加"} チャットメンバーを追加
     .chat-group-form__field--right
       .chat-group-form__search.clearfix
-        %input#user-search-field.chat-group-form__input{:placeholder => "追加したいユーザー名を入力してください", :type => "text"}/
+        %input#user-search-field.chat-group-form__input{placeholder: "追加したいユーザー名を入力してください", type: "text"}/
         #user-search-result      
     .chat-group-form__field.clearfix
       .chat-group-form__field--left
@@ -25,7 +25,7 @@
         #chat-group-users
           .chat-group-user.clearfix
             #chat-group-user.clearfix.js-chat-member
-              %input{:name => "group[user_ids][]", :type => "hidden"}/
+              %input{name: "group[user_ids][]", type: "hidden"}/
             %p.chat-group-user__name
               = current_user.name   
   .chat-group-form__field.clearfix

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -18,15 +18,16 @@
       .chat-group-form__search.clearfix
         %input#user-search-field.chat-group-form__input{:placeholder => "追加したいユーザー名を入力してください", :type => "text"}/
         #user-search-result      
-  .chat-group-form__field.clearfix
-    .chat-group-form__field--left
-      = f.label :name,"チャットメンバー",class: "chat-group-form__label"
-    .chat-group-form__field--right
-      #chat-group-users
-        .chat-group-user.clearfix
-          %input{:name => "group[user_ids][]", :type => "hidden"}/
-          %p.chat-group-user__name
-            = current_user.name   
+    .chat-group-form__field.clearfix
+      .chat-group-form__field--left
+        = f.label :name,"チャットメンバー",class: "chat-group-form__label"
+      .chat-group-form__field--right
+        #chat-group-users
+          .chat-group-user.clearfix
+            #chat-group-user.clearfix.js-chat-member
+              %input{:name => "group[user_ids][]", :type => "hidden"}/
+            %p.chat-group-user__name
+              = current_user.name   
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
     .chat-group-form__field--right

--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -26,7 +26,6 @@
       .chat-group-form__field--right
         #chat-group-users
           .chat-group-user.clearfix
-            %input{:name => "group[user_ids][]", :type => "hidden"}/
             %p.chat-group-user__name
               = current_user.name
     .chat-group-form__field.clearfix

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.message
+.message{"data-message-id": "#{message.id}"}
   .upper-message
     .upper-message__user-name
       = message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,5 +1,4 @@
-json.content @message.content
-json.image @message.image.url
+json.(@message, :content, :image)
 json.name @message.user.name
-json.created_at @message.created_at
+json.created_at @message.created_at.strftime("%Y/%m/%d %H:%M")
 json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,9 @@ Rails.application.routes.draw do
   resources :users, only: [:edit, :update, :index]
   resources :groups, only: [:new, :create, :destory, :edit, :update] do
     resources :messages, only: [:index, :create]
+
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
# What
自動更新を実装する。数秒おきに自動で、ブラウザに表示されているメッセージのうち最新のメッセージのidをサーバにリクエスト、サーバ側で後に投稿されたメッセージのみを取得してレスポンスし、最後クライアント側のJavaScriptで加工してメッセージ一覧に追加。
# Why
使うチャット画面を別のチャット画面で共有するときにリロードなしでメッセージを更新させるため。